### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server implementation that provides access to Linear's issue tracking system through a standardized interface.
 
+<a href="https://glama.ai/mcp/servers/83wkbjoqvn"><img width="380" height="200" src="https://glama.ai/mcp/servers/83wkbjoqvn/badge" alt="Linear Server MCP server" /></a>
+
 ## Features
 
 * Query Linear issues by ID or key


### PR DESCRIPTION
This PR adds a badge for the [Linear MCP Server](https://glama.ai/mcp/servers/83wkbjoqvn) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/83wkbjoqvn"><img width="380" height="200" src="https://glama.ai/mcp/servers/83wkbjoqvn/badge" alt="Linear Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.